### PR TITLE
BUGFIX: change resource id in cloud service in Pub/Sub (#8)

### DIFF
--- a/src/spaceone/inventory/model/pub_sub/schema/cloud_service.py
+++ b/src/spaceone/inventory/model/pub_sub/schema/cloud_service.py
@@ -32,7 +32,7 @@ schema_meta = CloudServiceMeta.set_layouts([schema_meta])
 
 
 class PubSubResource(CloudServiceResource):
-    cloud_service_group = StringType(default='PubSub')
+    cloud_service_group = StringType(default='Pub/Sub')
 
 
 class SchemaResource(PubSubResource):

--- a/src/spaceone/inventory/model/pub_sub/schema/data.py
+++ b/src/spaceone/inventory/model/pub_sub/schema/data.py
@@ -12,7 +12,7 @@ class Schema(BaseResource):
 
     def reference(self):
         return {
-            "resource_id": self.self_link,
+            "resource_id": self.id,
             "external_link": f"https://console.cloud.google.com/cloudpubsub/schema/detail/{self.id}?project={self.project}"
         }
 

--- a/src/spaceone/inventory/model/pub_sub/snapshot/cloud_service.py
+++ b/src/spaceone/inventory/model/pub_sub/snapshot/cloud_service.py
@@ -16,7 +16,7 @@ snapshot_meta = CloudServiceMeta.set_layouts([snapshot])
 
 
 class PubSubResource(CloudServiceResource):
-    cloud_service_group = StringType(default='PubSub')
+    cloud_service_group = StringType(default='Pub/Sub')
 
 
 class SnapshotResource(PubSubResource):

--- a/src/spaceone/inventory/model/pub_sub/snapshot/data.py
+++ b/src/spaceone/inventory/model/pub_sub/snapshot/data.py
@@ -12,6 +12,6 @@ class Snapshot(BaseResource):
 
     def reference(self):
         return {
-            "resource_id": self.self_link,
+            "resource_id": self.id,
             "external_link": f"https://console.cloud.google.com/cloudpubsub/snapshot/detail/{self.id}?project={self.project}"
         }

--- a/src/spaceone/inventory/model/pub_sub/subscription/data.py
+++ b/src/spaceone/inventory/model/pub_sub/subscription/data.py
@@ -68,6 +68,6 @@ class Subscription(BaseResource):
 
     def reference(self):
         return {
-            "resource_id": self.self_link,
+            "resource_id": self.id,
             "external_link": f"https://console.cloud.google.com/cloudpubsub/subscription/detail/{self.id}?project={self.project}"
         }

--- a/src/spaceone/inventory/model/pub_sub/topic/data.py
+++ b/src/spaceone/inventory/model/pub_sub/topic/data.py
@@ -97,6 +97,6 @@ class Topic(BaseResource):
 
     def reference(self):
         return {
-            "resource_id": self.self_link,
+            "resource_id": self.topic_id,
             "external_link": f"https://console.cloud.google.com/cloudpubsub/topic/detail/{self.topic_id}?project={self.project}"
         }


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
As reosurce_id is written as an empty str while ignoring the role played by resource_id, a problem of recognizing multiple objects as one in inventory's change_history occurred and was corrected.

**The collector only collects, and it is determined by the inventory core service to determine which category the collected CloudService belongs to.**
### Known issue
- #8 