### PR TITLE
feat: add output_display field in schema of Pub/Sub (#8)

### DIFF
--- a/src/spaceone/inventory/manager/pub_sub/schema_manager.py
+++ b/src/spaceone/inventory/manager/pub_sub/schema_manager.py
@@ -60,10 +60,15 @@ class SchemaManager(GoogleCloudManager):
                 ##################################
                 # 3. Make schema data
                 ##################################
+                display = {
+                    'output_display': 'show'
+                }
+
                 schema.update({
                     'id': schema_id,
                     'project': project_id,
-                    'schema_type': schema.get('type')
+                    'schema_type': schema.get('type'),
+                    'display': display
                 })
                 schema_data = Schema(schema, strict=False)
 

--- a/src/spaceone/inventory/model/pub_sub/schema/cloud_service.py
+++ b/src/spaceone/inventory/model/pub_sub/schema/cloud_service.py
@@ -13,7 +13,7 @@ schema_details = ItemDynamicLayout.set_fields('Schema', fields=[
 ])
 
 definition = ItemDynamicLayout.set_fields('Definition', fields=[
-    MoreField.data_source('Definition', 'data.definition', options={
+    MoreField.data_source('Definition', 'data.display.output_display', options={
         'sub_key': 'data.definition',
         'layout': {
             'name': 'Definition',

--- a/src/spaceone/inventory/model/pub_sub/schema/data.py
+++ b/src/spaceone/inventory/model/pub_sub/schema/data.py
@@ -1,6 +1,10 @@
-from schematics.types import StringType
-
+from schematics.types import StringType, ModelType
+from schematics import Model
 from spaceone.inventory.libs.schema.cloud_service import BaseResource
+
+
+class Display(Model):
+    output_display = StringType(serialize_when_none=False, default='show')
 
 
 class Schema(BaseResource):
@@ -9,6 +13,7 @@ class Schema(BaseResource):
     definition = StringType(serialize_when_none=False)
     revision_id = StringType(serialize_when_none=False, deserialize_from='revisionId')
     revision_create_time = StringType(serialize_when_none=False, deserialize_from='revisionCreateTime')
+    display = ModelType(Display, serialize_when_none=False)
 
     def reference(self):
         return {


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@mz.co.kr>

### Category
- [ ] New feature
- [ ] Bug fix
- [x] Improvement
- [ ] Refactor
- [ ] etc

### Description
<img width="1247" alt="스크린샷 2022-10-26 오전 12 15 03" src="https://user-images.githubusercontent.com/83386688/197813237-5bfb3b9b-831c-4abe-ae02-a40bfe7cf22f.png">

If the schema definition is long, it is limited to display in the console, so it is handled as a popup when show is pressed.

### Known issue
* #8