### PR TITLE
Add google-cloud-storage in requirements to use cloud functions

### DIFF
--- a/pkg/pip_requirements.txt
+++ b/pkg/pip_requirements.txt
@@ -4,3 +4,4 @@ spaceone-tester
 google-api-python-client
 schematics
 MarkupSafe>=2.0.0rc2
+google-cloud-storage


### PR DESCRIPTION
Signed-off-by: Seolmin Kwon <seolmin@megazone.com>

### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
The google-cloud-storage package is used by cloud functions to access the cloud build service and get the actual source code.


### Known issue
* #13 