### PR TITLE
Add memory_allocated field in model of cloud functions

### DIFF
--- a/src/spaceone/inventory/connector/cloud_functions/function.py
+++ b/src/spaceone/inventory/connector/cloud_functions/function.py
@@ -28,9 +28,4 @@ class FunctionConnector(GoogleCloudConnector):
     def _make_parent(self):
         return f'projects/{self.project_id}/locations/-'
 
-    def get_artifact(self):
-        self.client(googleapiclient='artifact', )
-        self.google_client_service = 'artifact'
-        self.version = 'v1'
-
 

--- a/src/spaceone/inventory/model/cloud_functions/function/cloud_service_type.py
+++ b/src/spaceone/inventory/model/cloud_functions/function/cloud_service_type.py
@@ -39,7 +39,7 @@ cst_function._metadata = CloudServiceTypeMeta.set_meta(
         TextDyField.data_source('Region', 'region_code'),
         TextDyField.data_source('Trigger', 'data.display.trigger'),
         TextDyField.data_source('Runtime', 'data.display.runtime'),
-        TextDyField.data_source('Memory allocated', 'data.service_config.available_memory'),
+        TextDyField.data_source('Memory allocated', 'data.display.memory_allocated'),
         TextDyField.data_source('Timeout', 'data.display.timeout'),
         TextDyField.data_source('Executed function', 'data.build_config.entry_point'),
     ],

--- a/src/spaceone/inventory/model/cloud_functions/function/data.py
+++ b/src/spaceone/inventory/model/cloud_functions/function/data.py
@@ -16,6 +16,7 @@ class FunctionDisplay(Model):
     trigger = StringType(serialize_when_none=False)
     runtime = StringType(serialize_when_none=False)
     timeout = StringType(serialize_when_none=False)
+    memory_allocated = StringType(serialize_when_none=False)
     vpc_connector_egress_settings = StringType(serialize_when_none=False)
     ingress_settings = StringType(serialize_when_none=False)
     source_location = StringType(serialize_when_none=False)


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
The memory_allocated field is a required value that function instances always have.
It was corrected because it was missing in the model.

### Known issue
* #20