### PR TITLE
Change has_gpu search field default to boolean in Compute engine service

### DIFF
--- a/src/spaceone/inventory/model/compute_engine/instance/cloud_service_type.py
+++ b/src/spaceone/inventory/model/compute_engine/instance/cloud_service_type.py
@@ -190,7 +190,7 @@ cst_vm_instance._metadata = CloudServiceTypeMeta.set_meta(
                             'TERMINATED': {'label': 'Terminated'}
                         }),
         SearchField.set(name='Instance Type', key='data.compute.instance_type'),
-        SearchField.set(name='Has GPU', key='data.display.has_gpu'),
+        SearchField.set(name='Has GPU', key='data.display.has_gpu', data_type='boolean'),
         SearchField.set(name='Total GPU Count', key='data.total_gpu_count', data_type='integer'),
         SearchField.set(name='GPUs', key='data.display.gpus'),
         SearchField.set(name='Key Pair', key='data.compute.keypair'),


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
* Change has_gpu search field default to boolean in Compute engine…